### PR TITLE
chore(subprojects/libgtkflow): update to 0.8.0

### DIFF
--- a/subprojects/libgtkflow.wrap
+++ b/subprojects/libgtkflow.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = libgtkflow
 url = https://notabug.org/grindhold/libgtkflow.git
-revision = 0.6.0
+revision = 0.8.0


### PR DESCRIPTION
also `0.6.0` is not building anymore with the current versions:
```
$ meson --version
0.61.1
$ ninja --version
1.10.2
```